### PR TITLE
Update - Automatic package scanning for entities declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ The Persistence Factory is ment to be cached and reused throught the application
     </bean>
 ```
 
+A handy way of handling multiple entities without declaring each exists. Declare a base package where all classes will be added to your PersistenceFactory :
+
+```xml
+         <property name="entitiesPkg" value="com.yourcompany.domain">
+```
+
 ```java
 @Autowired
 private PersistenceFactory persistenceFactory

--- a/src/main/java/org/firebrandocm/dao/AbstractPersistenceFactory.java
+++ b/src/main/java/org/firebrandocm/dao/AbstractPersistenceFactory.java
@@ -29,14 +29,17 @@ import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.firebrandocm.dao.annotations.ColumnFamily;
 import org.firebrandocm.dao.cql.QueryBuilder;
 import org.firebrandocm.dao.events.*;
 import org.firebrandocm.dao.impl.*;
 import org.firebrandocm.dao.ocmcql.CQLMappedCollectionValueConverter;
 import org.firebrandocm.dao.ocmcql.CQLMappedEntityValueConverter;
+import org.firebrandocm.dao.utils.ClassUtil;
 import org.firebrandocm.dao.utils.ObjectUtils;
 import org.firebrandocm.dao.utils.embedded.EmbeddedCassandraServer;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -396,6 +399,15 @@ public abstract class AbstractPersistenceFactory implements PersistenceFactory {
      */
     public void setEntities(List<Class<?>> entities) {
         this.entities = entities;
+    }
+
+    /**
+     * Sets the factory entities base package
+     *
+     * @param entitiesPkg
+     */
+    public void setEntitiesPkg(String entitiesPkg) throws IOException, ClassNotFoundException {
+      setEntities(ClassUtil.get(entitiesPkg, ColumnFamily.class));
     }
 
     /**

--- a/src/main/java/org/firebrandocm/dao/utils/ClassUtil.java
+++ b/src/main/java/org/firebrandocm/dao/utils/ClassUtil.java
@@ -1,0 +1,90 @@
+package org.firebrandocm.dao.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+
+/**
+ * This class starts and stops embedded Cassandra server.
+ * <p/>
+ * For instance of server is created temporary directory (in target/tmp) for data files and configuration.
+ *
+ * @author J. Revault d'A...
+ */
+public class ClassUtil {
+
+  /**
+   * Scans all classes accessible from the context class loader which belong to the given package and subpackages.
+   *
+   * @param packageName The base package
+   * @return The classes as a List
+   * @throws ClassNotFoundException
+   * @throws IOException
+   */
+  public static List<Class<?>> get( String packageName ) throws ClassNotFoundException, IOException {
+    return get( packageName, null );
+  }
+
+  /**
+   * Scans all classes accessible from the context class loader which belong to the given package and subpackages.
+   * Only if the class has the given annotation
+   *
+   * @param packageName The base package
+   * @param  annotation the annotation class we are looking for, null if not used
+   * @return The classes as a List
+   * @throws ClassNotFoundException
+   * @throws IOException
+   */
+  public static List<Class<?>> get( String packageName, Class<?> annotation ) throws ClassNotFoundException, IOException {
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+    assert classLoader != null;
+    String path = packageName.replace( '.', '/' );
+    Enumeration<URL> resources = classLoader.getResources( path );
+    List<File> dirs = new ArrayList<File>();
+    while ( resources.hasMoreElements() ) {
+      URL resource = resources.nextElement();
+      dirs.add( new File( resource.getFile() ) );
+    }
+    List<Class<?>> classes = new ArrayList<Class<?>>();
+    for ( File directory : dirs ) {
+      classes.addAll( findClasses( directory, packageName, annotation ) );
+    }
+    return classes;
+  }
+
+  /**
+   * Recursive method used to find all classes in a given directory and subdirs.
+   *
+   * @param directory   The base directory
+   * @param packageName The package name for classes found inside the base directory
+   * @return The classes as a List
+   * @throws ClassNotFoundException
+   */
+  public static List<Class<?>> findClasses( File directory, String packageName, Class annotation ) throws ClassNotFoundException {
+    List<Class<?>> classes = new ArrayList<Class<?>>();
+    if ( ! directory.exists() ) {
+      return classes;
+    }
+    File[] files = directory.listFiles();
+    if ( files != null ) for ( File file : files ) {
+      if ( file.isDirectory() ) {
+        assert ! file.getName().contains( "." );
+        classes.addAll( findClasses( file, packageName + "." + file.getName(), annotation ) );
+      }
+      else if ( file.getName().endsWith( ".class" ) ) {
+
+        // TEST added in order to ignore classes names with $
+        if ( ! file.getName().contains( "$" ) ) {
+          Class<?> clazz = Class.forName( packageName + '.' + file.getName().substring( 0, file.getName().length() - 6 ) );
+          if ( annotation != null && clazz.getAnnotation( annotation ) != null ) {
+            classes.add( clazz );
+          }
+        }
+      }
+    }
+    return classes;
+  }
+}

--- a/src/test/java/org/firebrandocm/tests/HectorAbstractTestCase.java
+++ b/src/test/java/org/firebrandocm/tests/HectorAbstractTestCase.java
@@ -21,7 +21,9 @@ package org.firebrandocm.tests;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.firebrandocm.dao.Query;
+import org.firebrandocm.dao.annotations.ColumnFamily;
 import org.firebrandocm.dao.impl.hector.HectorPersistenceFactory;
+import org.firebrandocm.dao.utils.ClassUtil;
 import org.junit.AfterClass;
 import org.junit.Before;
 
@@ -63,7 +65,23 @@ public abstract class HectorAbstractTestCase {
 	protected static List<Class<?>> persistentClasses;
 
 
-	public static void initWithClasses(Class<?>... clazzez) throws Exception {
+    public static void initWithClasses(String clazzezPkg) throws Exception {
+      factory = new HectorPersistenceFactory();
+      factory.setDefaultKeySpace(DEFAULT_KEYSPACE);
+      factory.setContactNodes(new String[]{RPC_LISTEN_ADDRESS});
+      factory.setPoolName("Main");
+      factory.setDebug(false);
+      factory.setThriftPort(RPC_PORT);
+      factory.setStartEmbeddedServer(START_EMBEDDED_SERVER);
+      factory.setEmbeddedServerBaseDir(BASE_DIRECTORY);
+      factory.setCleanupDirectories(CLEAN_UP_DIRECTORIES);
+      factory.setEntitiesPkg( clazzezPkg );
+      factory.setDropOnDestroy(DROP_ON_DESTROY);
+      factory.init();
+      persistentClasses = ClassUtil.get( clazzezPkg, ColumnFamily.class );
+    }
+
+    public static void initWithClasses(Class<?>... clazzez) throws Exception {
 		List<Class<?>> classList = Arrays.asList(clazzez);
 		factory = new HectorPersistenceFactory();
 		factory.setDefaultKeySpace(DEFAULT_KEYSPACE);

--- a/src/test/java/org/firebrandocm/tests/PersistenceOperationTest.java
+++ b/src/test/java/org/firebrandocm/tests/PersistenceOperationTest.java
@@ -41,7 +41,8 @@ public class PersistenceOperationTest extends HectorAbstractTestCase {
 
 	@BeforeClass
 	public static void init() throws Exception {
-		initWithClasses(FirstEntity.class, SecondEntity.class, FirstEntityCounter.class);
+		//initWithClasses(FirstEntity.class, SecondEntity.class, FirstEntityCounter.class);
+		initWithClasses("org.firebrandocm.tests");
 	}
 
 	/**


### PR DESCRIPTION
Hello 47deg,

This pull request (is my first one on github, I hope I did it correctly) adds the capacity of declaring a base package for entities, instead of declaring each class individually.
- XML style :
  &lt;property name="entitiesPkg" value="com.mypackage.domain.model" /&gt;
- JAVA style :
    factory.setEntitiesPkg( "com.mypackage.domain.model" );

Only the classes that have an @ColumnFamily annotation are taking into account.
All tests passes.

Have a nice day,
Julien

Signed-off-by: jrevault jrevault@gmail.com
