### PR TITLE
Added type converter for byte[] properties

### DIFF
--- a/src/main/java/org/firebrandocm/dao/AbstractPersistenceFactory.java
+++ b/src/main/java/org/firebrandocm/dao/AbstractPersistenceFactory.java
@@ -820,6 +820,8 @@ public abstract class AbstractPersistenceFactory implements PersistenceFactory {
             typeConverters.put(long.class, new LongTypeConverter());
             typeConverters.put(double.class, new DoubleTypeConverter());
             typeConverters.put(int.class, new IntegerTypeConverter());
+            typeConverters.put(byte[].class, new ByteArrayTypeConverter());
+            typeConverters.put(Byte[].class, new ByteArrayTypeConverter());
             typeConverters.put(Object.class, new ObjectBytesTypeConverter());
         }
     }

--- a/src/main/java/org/firebrandocm/dao/impl/ByteArrayTypeConverter.java
+++ b/src/main/java/org/firebrandocm/dao/impl/ByteArrayTypeConverter.java
@@ -1,0 +1,21 @@
+package org.firebrandocm.dao.impl;
+
+import me.prettyprint.cassandra.serializers.BytesArraySerializer;
+import org.firebrandocm.dao.TypeConverter;
+
+import java.nio.ByteBuffer;
+
+/**
+ * byte[] Type converter to serialize to and from ByteBuffer's
+ */
+public class ByteArrayTypeConverter implements TypeConverter<byte[]> {
+    @Override
+    public ByteBuffer toValue(byte[] value) throws Exception {
+        return BytesArraySerializer.get().toByteBuffer(value);
+    }
+
+    @Override
+    public byte[] fromValue(ByteBuffer value) throws Exception {
+        return BytesArraySerializer.get().fromByteBuffer(value);
+    }
+}

--- a/src/test/java/org/firebrandocm/tests/FirstEntity.java
+++ b/src/test/java/org/firebrandocm/tests/FirstEntity.java
@@ -61,6 +61,12 @@ public class FirstEntity {
 	@Column(validationClass = LongType.class)
 	private Date otherDate;
 
+    @Column(validationClass = BytesType.class)
+    private byte[] someBytes;
+
+    @Column(validationClass = BytesType.class)
+    private Byte[] someMoreBytes;
+
 	@Mapped
 	private FirstEntityCounter counter;
 
@@ -225,7 +231,23 @@ public class FirstEntity {
 		this.prePersistProperty = prePersistProperty;
 	}
 
-	@OnEvent(Event.Entity.PRE_PERSIST)
+    public byte[] getSomeBytes() {
+        return someBytes;
+    }
+
+    public void setSomeBytes(byte[] someBytes) {
+        this.someBytes = someBytes;
+    }
+
+    public Byte[] getSomeMoreBytes() {
+        return someMoreBytes;
+    }
+
+    public void setSomeMoreBytes(Byte[] someMoreBytes) {
+        this.someMoreBytes = someMoreBytes;
+    }
+
+    @OnEvent(Event.Entity.PRE_PERSIST)
 	public void onPrePersist() {
 		setPrePersistProperty(UUID.randomUUID().toString());
 	}

--- a/src/test/java/org/firebrandocm/tests/PersistenceOperationTest.java
+++ b/src/test/java/org/firebrandocm/tests/PersistenceOperationTest.java
@@ -25,6 +25,7 @@ import org.firebrandocm.dao.cql.clauses.Predicate;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
@@ -242,6 +243,16 @@ public class PersistenceOperationTest extends HectorAbstractTestCase {
 		factory.persist(firstEntity);
 		testPropertyLazyAccess(FirstEntity.class, firstEntity.getId(), "listProperty");
 	}
+
+    @Test
+    public void testEQByteArrayProperties() throws NoSuchFieldException, IllegalAccessException, InvocationTargetException, NoSuchMethodException, UnsupportedEncodingException {
+        String test = UUID.randomUUID().toString();
+        FirstEntity firstEntity = new FirstEntity();
+        firstEntity.setSomeBytes(test.getBytes());
+        factory.persist(firstEntity);
+        FirstEntity loadedEntity = factory.get(FirstEntity.class, firstEntity.getId());
+        assertEquals(new String(loadedEntity.getSomeBytes(), "UTF-8"), test);
+    }
 
 	@Test
 	public void testEQLongIndexedProperty() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {


### PR DESCRIPTION
Thanks to Ben Reeves for pointing this out. No need to serialize byte[] properties.
