### PR TITLE
added annotation attribute to customize the column family name

### DIFF
--- a/src/main/java/org/firebrandocm/dao/ClassMetadata.java
+++ b/src/main/java/org/firebrandocm/dao/ClassMetadata.java
@@ -215,7 +215,7 @@ public class ClassMetadata<T> {
             consistencyLevel = columnFamilyAnnotation.consistencyLevel();
             counterColumnFamily = columnFamilyAnnotation.defaultValidationClass() == CounterColumnType.class;
             keySpace = StringUtils.defaultIfEmpty(columnFamilyAnnotation.keySpace(), persistenceFactory.getDefaultKeySpace());
-            columnFamily = target.getSimpleName();
+            columnFamily = StringUtils.defaultIfEmpty(columnFamilyAnnotation.name(), target.getSimpleName());
             initializeColumnFamilyDefinition();
             processFields(target, "");
             processMethods(target);

--- a/src/main/java/org/firebrandocm/dao/annotations/ColumnFamily.java
+++ b/src/main/java/org/firebrandocm/dao/annotations/ColumnFamily.java
@@ -83,6 +83,12 @@ public @interface ColumnFamily {
 	 */
 	String keySpace() default "";
 
+    /**
+     *
+     * @return the physical column family name this entity will be mapped to
+     */
+    String name() default "";
+
 	/**
 	 *
 	 * @return the number of keys per sstable whose


### PR DESCRIPTION
previously the columnfamily name was hardcoded to the classname, added
option to customize this name

to firebrandocm authors:
Am I missing something here? It almost seemed too easy to fix, so I suspect you had a reason to not implement it in the first place. Are there other pieces of code that depends on the columnfamily being the same as the classname?
Seems to work fine though... but please reject the pull request if I've missed something.

The reason we need this btw is because we have naming conventions in our cassandra cluster we're trying to adhere to...

Thanks!
