### PR TITLE
fixed bug that didn't resolve the @ColumnFamily name attribute in all cases

### DIFF
--- a/src/main/java/org/firebrandocm/dao/ClassMetadata.java
+++ b/src/main/java/org/firebrandocm/dao/ClassMetadata.java
@@ -31,6 +31,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.firebrandocm.dao.annotations.*;
 import org.firebrandocm.dao.events.Event;
+import org.firebrandocm.dao.utils.ClassUtil;
 import org.firebrandocm.dao.utils.ObjectUtils;
 
 import java.beans.IntrospectionException;
@@ -215,7 +216,7 @@ public class ClassMetadata<T> {
             consistencyLevel = columnFamilyAnnotation.consistencyLevel();
             counterColumnFamily = columnFamilyAnnotation.defaultValidationClass() == CounterColumnType.class;
             keySpace = StringUtils.defaultIfEmpty(columnFamilyAnnotation.keySpace(), persistenceFactory.getDefaultKeySpace());
-            columnFamily = StringUtils.defaultIfEmpty(columnFamilyAnnotation.name(), target.getSimpleName());
+            columnFamily = ClassUtil.getColumnFamilyName(target);
             initializeColumnFamilyDefinition();
             processFields(target, "");
             processMethods(target);

--- a/src/main/java/org/firebrandocm/dao/cql/QueryBuilder.java
+++ b/src/main/java/org/firebrandocm/dao/cql/QueryBuilder.java
@@ -21,14 +21,15 @@ package org.firebrandocm.dao.cql;
 import org.apache.cassandra.locator.AbstractReplicationStrategy;
 import org.apache.cassandra.thrift.IndexOperator;
 import org.firebrandocm.dao.cql.clauses.*;
-import org.firebrandocm.dao.cql.clauses.Set;
 import org.firebrandocm.dao.cql.converters.CQLDateValueConverter;
 import org.firebrandocm.dao.cql.converters.CQLGenericObjectValueConverter;
 import org.firebrandocm.dao.cql.converters.CQLStringValueConverter;
 import org.firebrandocm.dao.cql.converters.CQLValueConverter;
 import org.firebrandocm.dao.cql.statement.*;
+import org.firebrandocm.dao.utils.ClassUtil;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Constructs CQL queries
@@ -214,7 +215,7 @@ public class QueryBuilder {
 	}
 
 	public static ColumnFamily columnFamily(Class<?> entityClass) {
-		return columnFamily(entityClass.getSimpleName());
+		return columnFamily(ClassUtil.getColumnFamilyName(entityClass));
 	}
 
 	public static OnColumnFamily onColumnFamily(String columnFamily) {
@@ -222,7 +223,7 @@ public class QueryBuilder {
 	}
 
 	public static OnColumnFamily onColumnFamily(Class<?> entityClass) {
-		return onColumnFamily(entityClass.getSimpleName());
+		return onColumnFamily(ClassUtil.getColumnFamilyName(entityClass));
 	}
 
 	public static First first(int first) {
@@ -246,7 +247,7 @@ public class QueryBuilder {
 	}
 
 	public static From from(Class<?> entityClass) {
-		return new From(entityClass.getSimpleName());
+        return new From(ClassUtil.getColumnFamilyName(entityClass));
 	}
 
 	public static From from(String columnFamily) {

--- a/src/main/java/org/firebrandocm/dao/utils/ClassUtil.java
+++ b/src/main/java/org/firebrandocm/dao/utils/ClassUtil.java
@@ -1,5 +1,7 @@
 package org.firebrandocm.dao.utils;
 
+import org.apache.commons.lang3.StringUtils;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -87,4 +89,16 @@ public class ClassUtil {
     }
     return classes;
   }
+
+    /**
+     * Resolves the physical column family name for this class by checking for a @ColumnFamily(name = ) annotation
+     * or if not present falls back to class.getSimpleName()
+     *
+     * @param entityClass class to look for column family annotation
+     * @return the configured column family name as a String
+     */
+    public static String getColumnFamilyName(Class<?> entityClass) {
+        org.firebrandocm.dao.annotations.ColumnFamily columnFamilyAnnotation = entityClass.getAnnotation(org.firebrandocm.dao.annotations.ColumnFamily.class);
+        return StringUtils.defaultIfEmpty(columnFamilyAnnotation.name(), entityClass.getSimpleName());
+    }
 }

--- a/src/test/java/org/firebrandocm/tests/HectorAbstractTestCase.java
+++ b/src/test/java/org/firebrandocm/tests/HectorAbstractTestCase.java
@@ -78,7 +78,7 @@ public abstract class HectorAbstractTestCase {
       factory.setEntitiesPkg( clazzezPkg );
       factory.setDropOnDestroy(DROP_ON_DESTROY);
       factory.init();
-      persistentClasses = ClassUtil.get( clazzezPkg, ColumnFamily.class );
+      persistentClasses = ClassUtil.get(clazzezPkg, ColumnFamily.class);
     }
 
     public static void initWithClasses(Class<?>... clazzez) throws Exception {
@@ -104,12 +104,14 @@ public abstract class HectorAbstractTestCase {
 			throw new IllegalStateException("set persistentClassNames in @BeforeClass");
 		}
 		for (Class<?> persistentClass : persistentClasses) {
+            String columnFamilyName = ClassUtil.getColumnFamilyName(persistentClass);
+
 			factory.executeQuery(Integer.class, Query.get(truncate(
-					columnFamily(persistentClass.getSimpleName())
+					columnFamily(columnFamilyName)
 			)));
 			List<?> results = factory.getResultList(persistentClass, Query.get(select(
 					allColumns(),
-					from(persistentClass.getSimpleName())
+					from(columnFamilyName)
 			)));
 			assertEquals(0, results.size());
 		}

--- a/src/test/java/org/firebrandocm/tests/QueryBuilderParserTest.java
+++ b/src/test/java/org/firebrandocm/tests/QueryBuilderParserTest.java
@@ -24,6 +24,7 @@ import org.firebrandocm.dao.cql.clauses.ColumnDataType;
 import org.firebrandocm.dao.cql.clauses.ConsistencyType;
 import org.firebrandocm.dao.cql.clauses.StorageParameter;
 import org.firebrandocm.dao.cql.statement.Statement;
+import org.firebrandocm.dao.utils.ClassUtil;
 import org.junit.Test;
 
 import java.text.SimpleDateFormat;
@@ -426,6 +427,12 @@ public class QueryBuilderParserTest {
 		test(String.format("FROM %s", FirstEntity.class.getSimpleName()), from(FirstEntity.class));
 		test("FROM FirstEntity", from("FirstEntity"));
 	}
+
+    @Test
+    public void testFromWithCustomColumnFamilyName() throws Exception {
+        test(String.format("FROM %s", ClassUtil.getColumnFamilyName(SecondEntity.class)), from(SecondEntity.class));
+        test("FROM class_secondentity", from("class_secondentity"));
+    }
 
 	@Test
 	public void testConsistency() throws Exception {

--- a/src/test/java/org/firebrandocm/tests/SecondEntity.java
+++ b/src/test/java/org/firebrandocm/tests/SecondEntity.java
@@ -23,7 +23,7 @@ import org.firebrandocm.dao.annotations.Embedded;
 import org.firebrandocm.dao.annotations.Key;
 import org.firebrandocm.dao.annotations.Mapped;
 
-@ColumnFamily
+@ColumnFamily(name = "class_secondentity")
 public class SecondEntity {
 
 	@Key


### PR DESCRIPTION
Good point, unit tests actually started failing when I added the name attribute to the SecondEntity test class.

Cassandra reads also did not work when the annotation was present. And the reason is the fix below. Also added a new unit test. Everything seems to be working now.

This fix is a bit more complicated than the first one but in essence all it does, or should do, is to replace all getSimpleName() entity occurances with the helper method. The helper method is in ClassUtil.getColumnFamilyName()

FIX:

class.getSimpleName() was present in several places in the code, added
helper method that scans for the @ColumnFamily annotation name attribute
and uses it as CF name if present, otherwise falls back to
getSimpleName()
